### PR TITLE
Update for ceci version 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "tensorflow",
     "tensorflow_probability",
     "scipy",
-    "pz_rail_base @ git+https://github.com/LSSTDESC/rail_base@ceci2",
+    "pz-rail-base>=1.0.3",
     "qp-prob[full]",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "tensorflow",
     "tensorflow_probability",
     "scipy",
-    "pz-rail-base",
+    "ceci2 @ https://github.com/LSSTDESC/rail_base",
     "qp-prob[full]",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "tensorflow",
     "tensorflow_probability",
     "scipy",
-    "ceci2 @ https://github.com/LSSTDESC/rail_base",
+    "ceci2 @ git+https://github.com/LSSTDESC/rail_base",
     "qp-prob[full]",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "tensorflow",
     "tensorflow_probability",
     "scipy",
-    "ceci2 @ git+https://github.com/LSSTDESC/rail_base",
+    "pz_rail_base @ git+https://github.com/LSSTDESC/rail_base@ceci2",
     "qp-prob[full]",
 ]
 

--- a/src/rail/estimation/algos/rail_inception.py
+++ b/src/rail/estimation/algos/rail_inception.py
@@ -145,7 +145,7 @@ class Inception(CatEstimator):
         
         self.nnmodel = None
         self.scale = None
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         
     
     def open_model(self, **kwargs):

--- a/src/rail/estimation/algos/rail_inception.py
+++ b/src/rail/estimation/algos/rail_inception.py
@@ -102,9 +102,6 @@ class Inform_Inception(CatInformer):
                           epoch=Param(int, 5),
                           hdf5_groupname=SHARED_PARAMS)
              
-                
-    def __init__(self, args, comm=None):
-        CatInformer.__init__(self, args, comm=comm)
         
     def run(self):
         """
@@ -142,13 +139,13 @@ class Inception(CatEstimator):
     config_options = CatEstimator.config_options.copy()
     config_options.update()
     
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """ Constructor:
         Do Estimator specific initialization """
         
         self.nnmodel = None
         self.scale = None
-        CatEstimator.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         
     
     def open_model(self, **kwargs):


### PR DESCRIPTION
This PR updates the constructors of all stage subclasses to work with ceci version 2, in which aliases are specified in the constructor. A similar PR has been opened for each RAIL repo.

The main change is to the the constructors to accept any keywords with **kwargs and pass them to the parent class.

I have also removed any constructors which did not do anything except call the parent class constructor. Since this happens automatically if you omit the constructor, these were redundant.

Finally, in constructors I have changed I have removed hard-coded parent classes in favour of the python3 recommended super() function. If the parent class are changed in the future the constructor will still work.